### PR TITLE
Fix resizing

### DIFF
--- a/src/legacy-gui.cpp
+++ b/src/legacy-gui.cpp
@@ -958,8 +958,7 @@ public:
                     /* Fl_Group::current()->resizable( o ); */
                 } // Fl_Scalepack
 
-                { Fl_Box *o = new Fl_Box( X + 300, Y + 30, 100, H - ( 30 + SH ));
-                    Fl_Group::current()->resizable(o);
+                { new Fl_Box( X + 1000, Y + 30, 100, H - ( 30 + SH ));
                 }
 
                 { Fl_Text_Display *o = status_display = new Fl_Text_Display( X, Y + H - SH, W, SH );


### PR DESCRIPTION
Fixes #64, #58

A small, resizable box in the bottom of the legacy GUI allowed the tree containing the session list to be scaled to zero width and thus to disappear.

As a side effect you one can now access the log messages at the bottom of the `nsm-legacy-gui` again. (Although initially covered by a scrollbar)